### PR TITLE
Relax versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ default = []
 serde = ["dep:serde", "bytes/serde"]
 
 [dependencies]
-bytes = "1.4.0"
-httparse = "1.8.0"
-pest = { version = "2.7.2" }
-pest_derive = { version = "2.7.2" }
-serde = { version = "1.0", features = ["derive"], optional = true }
-thiserror = "1.0.47"
+bytes = "1"
+httparse = "1"
+pest = { version = "2" }
+pest_derive = { version = "2" }
+serde = { version = "1", features = ["derive"], optional = true }
+thiserror = "1"


### PR DESCRIPTION
This PR relaxes the version requirements of dependencies. I ran into this, because this https://github.com/tlsnotary/tlsn/pull/360 does not compile.