### PR TITLE
Duplicate headers

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,7 +6,7 @@ mod types;
 use bytes::Bytes;
 
 pub use span::{parse_request, parse_response};
-pub use types::{Body, Header, HeaderName, HeaderValue, Request, Response};
+pub use types::{Body, Header, HeaderName, HeaderValue, Request, Response, SameNameHeaders};
 
 use crate::ParseError;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -111,20 +111,17 @@ mod tests {
 
         assert_eq!(reqs[0].method, "GET");
         assert!(reqs[0].body.is_none());
-        assert_eq!(
-            reqs[0].header("host").unwrap().value.as_bytes(),
-            b"localhost"
-        );
+        let headers_host = reqs[0].header("host").unwrap();
+        assert_eq!(headers_host.len(), 1);
+        assert_eq!(headers_host[0].value.as_bytes(), b"localhost");
 
         assert_eq!(reqs[1].method, "POST");
-        assert_eq!(
-            reqs[1].header("host").unwrap().value.as_bytes(),
-            b"localhost"
-        );
-        assert_eq!(
-            reqs[1].header("content-length").unwrap().value.as_bytes(),
-            b"14"
-        );
+        let headers_host = reqs[1].header("host").unwrap();
+        assert_eq!(headers_host.len(), 1);
+        assert_eq!(headers_host[0].value.as_bytes(), b"localhost");
+        let headers_content_length = reqs[1].header("content-length").unwrap();
+        assert_eq!(headers_content_length.len(), 1);
+        assert_eq!(headers_content_length[0].value.as_bytes(), b"14");
         assert_eq!(
             reqs[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
@@ -140,27 +137,24 @@ mod tests {
         assert_eq!(resps.len(), 3);
 
         assert_eq!(resps[0].code, "200");
-        assert_eq!(
-            resps[0].header("content-length").unwrap().value.as_bytes(),
-            b"0"
-        );
+        let headers_content_length = resps[0].header("content-length").unwrap();
+        assert_eq!(headers_content_length.len(), 1);
+        assert_eq!(headers_content_length[0].value.as_bytes(), b"0");
         assert!(resps[0].body.is_none());
 
         assert_eq!(resps[1].code, "200");
-        assert_eq!(
-            resps[1].header("content-length").unwrap().value.as_bytes(),
-            b"14"
-        );
+        let headers_content_length = resps[1].header("content-length").unwrap();
+        assert_eq!(headers_content_length.len(), 1);
+        assert_eq!(headers_content_length[0].value.as_bytes(), b"14");
         assert_eq!(
             resps[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
         );
 
         assert_eq!(resps[2].code, "204");
-        assert_eq!(
-            resps[2].header("content-length").unwrap().value.as_bytes(),
-            b"0"
-        );
+        let headers_content_length = resps[2].header("content-length").unwrap();
+        assert_eq!(headers_content_length.len(), 1);
+        assert_eq!(headers_content_length[0].value.as_bytes(), b"0");
         assert!(resps[2].body.is_none());
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,7 +6,7 @@ mod types;
 use bytes::Bytes;
 
 pub use span::{parse_request, parse_response};
-pub use types::{Body, Header, HeaderName, HeaderValue, Request, Response, SameNameHeaders};
+pub use types::{Body, Header, HeaderName, HeaderValue, Request, Response};
 
 use crate::ParseError;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -111,7 +111,20 @@ mod tests {
 
         assert_eq!(reqs[0].method, "GET");
         assert!(reqs[0].body.is_none());
+        assert_eq!(
+            reqs[0].header("host").unwrap().value.as_bytes(),
+            b"localhost"
+        );
+
         assert_eq!(reqs[1].method, "POST");
+        assert_eq!(
+            reqs[1].header("host").unwrap().value.as_bytes(),
+            b"localhost"
+        );
+        assert_eq!(
+            reqs[1].header("content-length").unwrap().value.as_bytes(),
+            b"14"
+        );
         assert_eq!(
             reqs[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
@@ -127,13 +140,27 @@ mod tests {
         assert_eq!(resps.len(), 3);
 
         assert_eq!(resps[0].code, "200");
+        assert_eq!(
+            resps[0].header("content-length").unwrap().value.as_bytes(),
+            b"0"
+        );
         assert!(resps[0].body.is_none());
+
         assert_eq!(resps[1].code, "200");
+        assert_eq!(
+            resps[1].header("content-length").unwrap().value.as_bytes(),
+            b"14"
+        );
         assert_eq!(
             resps[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
         );
+
         assert_eq!(resps[2].code, "204");
+        assert_eq!(
+            resps[2].header("content-length").unwrap().value.as_bytes(),
+            b"0"
+        );
         assert!(resps[2].body.is_none());
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -111,17 +111,20 @@ mod tests {
 
         assert_eq!(reqs[0].method, "GET");
         assert!(reqs[0].body.is_none());
-        let headers_host = reqs[0].header("host").unwrap();
-        assert_eq!(headers_host.len(), 1);
-        assert_eq!(headers_host[0].value.as_bytes(), b"localhost");
+        assert_eq!(
+            reqs[0].header("host").unwrap().value.as_bytes(),
+            b"localhost"
+        );
 
         assert_eq!(reqs[1].method, "POST");
-        let headers_host = reqs[1].header("host").unwrap();
-        assert_eq!(headers_host.len(), 1);
-        assert_eq!(headers_host[0].value.as_bytes(), b"localhost");
-        let headers_content_length = reqs[1].header("content-length").unwrap();
-        assert_eq!(headers_content_length.len(), 1);
-        assert_eq!(headers_content_length[0].value.as_bytes(), b"14");
+        assert_eq!(
+            reqs[1].header("host").unwrap().value.as_bytes(),
+            b"localhost"
+        );
+        assert_eq!(
+            reqs[1].header("content-length").unwrap().value.as_bytes(),
+            b"14"
+        );
         assert_eq!(
             reqs[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
@@ -137,24 +140,27 @@ mod tests {
         assert_eq!(resps.len(), 3);
 
         assert_eq!(resps[0].code, "200");
-        let headers_content_length = resps[0].header("content-length").unwrap();
-        assert_eq!(headers_content_length.len(), 1);
-        assert_eq!(headers_content_length[0].value.as_bytes(), b"0");
+        assert_eq!(
+            resps[0].header("content-length").unwrap().value.as_bytes(),
+            b"0"
+        );
         assert!(resps[0].body.is_none());
 
         assert_eq!(resps[1].code, "200");
-        let headers_content_length = resps[1].header("content-length").unwrap();
-        assert_eq!(headers_content_length.len(), 1);
-        assert_eq!(headers_content_length[0].value.as_bytes(), b"14");
+        assert_eq!(
+            resps[1].header("content-length").unwrap().value.as_bytes(),
+            b"14"
+        );
         assert_eq!(
             resps[1].body.as_ref().unwrap().span(),
             b"Hello, world!\n".as_slice()
         );
 
         assert_eq!(resps[2].code, "204");
-        let headers_content_length = resps[2].header("content-length").unwrap();
-        assert_eq!(headers_content_length.len(), 1);
-        assert_eq!(headers_content_length[0].value.as_bytes(), b"0");
+        assert_eq!(
+            resps[2].header("content-length").unwrap().value.as_bytes(),
+            b"0"
+        );
         assert!(resps[2].body.is_none());
     }
 }

--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -202,7 +202,7 @@ fn request_body_len(request: &Request) -> Result<usize, ParseError> {
     } else if let Some(h) = request.header("Content-Length") {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
         // defines the expected message body length in octets.
-        std::str::from_utf8(h[0].value.0.as_bytes())?
+        std::str::from_utf8(h.value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
@@ -233,7 +233,7 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
     } else if let Some(h) = response.header("Content-Length") {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
         // defines the expected message body length in octets.
-        std::str::from_utf8(h[0].value.0.as_bytes())?
+        std::str::from_utf8(h.value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
@@ -287,11 +287,11 @@ mod tests {
         assert_eq!(req.span(), TEST_REQUEST);
         assert_eq!(req.method, "GET");
         assert_eq!(
-            req.header("Host").unwrap()[0].value.span(),
+            req.header("Host").unwrap().value.span(),
             b"developer.mozilla.org".as_slice()
         );
         assert_eq!(
-            req.header("User-Agent").unwrap()[0].value.span(),
+            req.header("User-Agent").unwrap().value.span(),
             b"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0"
                 .as_slice()
         );
@@ -306,11 +306,11 @@ mod tests {
         assert_eq!(res.code, "200");
         assert_eq!(res.reason, "OK");
         assert_eq!(
-            res.header("Server").unwrap()[0].value.span(),
+            res.header("Server").unwrap().value.span(),
             b"Apache/2.2.14 (Win32)".as_slice()
         );
         assert_eq!(
-            res.header("Connection").unwrap()[0].value.span(),
+            res.header("Connection").unwrap().value.span(),
             b"Closed".as_slice()
         );
         assert_eq!(

--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -202,7 +202,7 @@ fn request_body_len(request: &Request) -> Result<usize, ParseError> {
     } else if let Some(h) = request.header("Content-Length") {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
         // defines the expected message body length in octets.
-        std::str::from_utf8(h.value.0.as_bytes())?
+        std::str::from_utf8(h[0].value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
@@ -233,7 +233,7 @@ fn response_body_len(response: &Response) -> Result<usize, ParseError> {
     } else if let Some(h) = response.header("Content-Length") {
         // If a valid Content-Length header field is present without Transfer-Encoding, its decimal value
         // defines the expected message body length in octets.
-        std::str::from_utf8(h.value.0.as_bytes())?
+        std::str::from_utf8(h[0].value.0.as_bytes())?
             .parse::<usize>()
             .map_err(|err| ParseError(format!("failed to parse Content-Length value: {err}")))
     } else {
@@ -287,11 +287,11 @@ mod tests {
         assert_eq!(req.span(), TEST_REQUEST);
         assert_eq!(req.method, "GET");
         assert_eq!(
-            req.header("Host").unwrap().value.span(),
+            req.header("Host").unwrap()[0].value.span(),
             b"developer.mozilla.org".as_slice()
         );
         assert_eq!(
-            req.header("User-Agent").unwrap().value.span(),
+            req.header("User-Agent").unwrap()[0].value.span(),
             b"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:50.0) Gecko/20100101 Firefox/50.0"
                 .as_slice()
         );
@@ -306,11 +306,11 @@ mod tests {
         assert_eq!(res.code, "200");
         assert_eq!(res.reason, "OK");
         assert_eq!(
-            res.header("Server").unwrap().value.span(),
+            res.header("Server").unwrap()[0].value.span(),
             b"Apache/2.2.14 (Win32)".as_slice()
         );
         assert_eq!(
-            res.header("Connection").unwrap().value.span(),
+            res.header("Connection").unwrap()[0].value.span(),
             b"Closed".as_slice()
         );
         assert_eq!(

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -66,6 +66,13 @@ impl Header {
     }
 }
 
+/// A collection of headers with the same name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SameNameHeaders<'a> {
+    /// Vector of headers with the same name.
+    pub headers: Vec<&'a Header>,
+}
+
 impl Spanned for Header {
     fn span(&self) -> &Span {
         &self.span
@@ -88,9 +95,7 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns all the request headers with the given name (case-insensitive). Returns `None` if
-    /// there are no matching headers. Returns `Some` if there is at least one matching header.
-    /// Never returns `Some` with an empty `Vec`.
+    /// Returns all the request headers with the given name (case-insensitive).
     pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
         let matching: Vec<&Header> = self
             .headers

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -66,13 +66,6 @@ impl Header {
     }
 }
 
-/// A collection of headers with the same name.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SameNameHeaders<'a> {
-    /// Vector of headers with the same name.
-    pub headers: Vec<&'a Header>,
-}
-
 impl Spanned for Header {
     fn span(&self) -> &Span {
         &self.span
@@ -95,7 +88,9 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns all the request headers with the given name (case-insensitive).
+    /// Returns all the request headers with the given name (case-insensitive). Returns `None` if
+    /// there are no matching headers. Returns `Some` if there is at least one matching header.
+    /// Never returns `Some` with an empty `Vec`.
     pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
         let matching: Vec<&Header> = self
             .headers

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -99,9 +99,10 @@ impl Request {
 
     /// Returns a `Vec` of all request headers associated with a name.
     pub fn all_headers_with_name(&self, name: &str) -> Vec<&Header> {
-        // TODO: use Option???
-        // TODO: implement
-        Vec::new()
+        self.headers
+            .iter()
+            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .collect()
     }
 
     /// Shifts the span range by the given offset.
@@ -151,9 +152,10 @@ impl Response {
 
     /// Returns a `Vec` of all response headers associated with a name.
     pub fn all_headers_with_name(&self, name: &str) -> Vec<&Header> {
-        // TODO: use Option???
-        // TODO: implement
-        Vec::new()
+        self.headers
+            .iter()
+            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .collect()
     }
 
     /// Shifts the span range by the given offset.

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -89,8 +89,8 @@ pub struct Request {
 
 impl Request {
     /// Returns the request header with the given name (case-insensitive). If there are multiple
-    /// headers associated with the name, then the first one is returned. Use `all_headers` to get
-    /// all values associated with a given name.
+    /// headers associated with the name, then the first one is returned. Use
+    /// `all_headers_with_name` to get all values associated with a given name.
     pub fn header(&self, name: &str) -> Option<&Header> {
         self.headers
             .iter()
@@ -98,9 +98,10 @@ impl Request {
     }
 
     /// Returns a `Vec` of all request headers associated with a name.
-    pub fn all_headers(&self, name: &str) -> Vec<&Header> {
+    pub fn all_headers_with_name(&self, name: &str) -> Vec<&Header> {
         // TODO: use Option???
         // TODO: implement
+        Vec::new()
     }
 
     /// Shifts the span range by the given offset.
@@ -140,8 +141,8 @@ pub struct Response {
 
 impl Response {
     /// Returns the response header with the given name (case-insensitive). If there are multiple
-    /// headers associated with the name, then the first one is returned. Use `all_headers` to get
-    /// all values associated with a given name.
+    /// headers associated with the name, then the first one is returned. Use
+    /// `all_headers_with_name` to get all values associated with a given name.
     pub fn header(&self, name: &str) -> Option<&Header> {
         self.headers
             .iter()
@@ -149,9 +150,10 @@ impl Response {
     }
 
     /// Returns a `Vec` of all response headers associated with a name.
-    pub fn all_headers(&self, name: &str) -> Vec<&Header> {
+    pub fn all_headers_with_name(&self, name: &str) -> Vec<&Header> {
         // TODO: use Option???
         // TODO: implement
+        Vec::new()
     }
 
     /// Shifts the span range by the given offset.

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -88,11 +88,19 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns the request header with the given name (case-insensitive).
+    /// Returns the request header with the given name (case-insensitive). If there are multiple
+    /// headers associated with the name, then the first one is returned. Use `all_headers` to get
+    /// all values associated with a given name.
     pub fn header(&self, name: &str) -> Option<&Header> {
         self.headers
             .iter()
             .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+    }
+
+    /// Returns a `Vec` of all request headers associated with a name.
+    pub fn all_headers(&self, name: &str) -> Vec<&Header> {
+        // TODO: use Option???
+        // TODO: implement
     }
 
     /// Shifts the span range by the given offset.
@@ -131,11 +139,19 @@ pub struct Response {
 }
 
 impl Response {
-    /// Returns the response header with the given name (case-insensitive).
+    /// Returns the response header with the given name (case-insensitive). If there are multiple
+    /// headers associated with the name, then the first one is returned. Use `all_headers` to get
+    /// all values associated with a given name.
     pub fn header(&self, name: &str) -> Option<&Header> {
         self.headers
             .iter()
             .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+    }
+
+    /// Returns a `Vec` of all response headers associated with a name.
+    pub fn all_headers(&self, name: &str) -> Vec<&Header> {
+        // TODO: use Option???
+        // TODO: implement
     }
 
     /// Shifts the span range by the given offset.

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -88,20 +88,11 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns all the request headers with the given name (case-insensitive). Returns `None` if
-    /// there are no matching headers. Returns `Some` if there is at least one matching header.
-    /// Never returns `Some` with an empty `Vec`.
-    pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
-        let matching: Vec<&Header> = self
-            .headers
+    /// Returns the request header with the given name (case-insensitive).
+    pub fn header(&self, name: &str) -> Option<&Header> {
+        self.headers
             .iter()
-            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
-            .collect();
-        if matching.is_empty() {
-            None
-        } else {
-            Some(matching)
-        }
+            .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
     }
 
     /// Shifts the span range by the given offset.
@@ -140,20 +131,11 @@ pub struct Response {
 }
 
 impl Response {
-    /// Returns all the response headers with the given name (case-insensitive). Returns `None` if
-    /// there are no matching headers. Returns `Some` if there is at least one matching header.
-    /// Never returns `Some` with an empty `Vec`.
-    pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
-        let matching: Vec<&Header> = self
-            .headers
+    /// Returns the response header with the given name (case-insensitive).
+    pub fn header(&self, name: &str) -> Option<&Header> {
+        self.headers
             .iter()
-            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
-            .collect();
-        if matching.is_empty() {
-            None
-        } else {
-            Some(matching)
-        }
+            .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
     }
 
     /// Shifts the span range by the given offset.

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -88,11 +88,20 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns the request header with the given name (case-insensitive).
-    pub fn header(&self, name: &str) -> Option<&Header> {
-        self.headers
+    /// Returns all the request headers with the given name (case-insensitive). Returns `None` if
+    /// there are no matching headers. Returns `Some` if there is at least one matching header.
+    /// Never returns `Some` with an empty `Vec`.
+    pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
+        let matching: Vec<&Header> = self
+            .headers
             .iter()
-            .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .collect();
+        if matching.is_empty() {
+            None
+        } else {
+            Some(matching)
+        }
     }
 
     /// Shifts the span range by the given offset.
@@ -131,11 +140,20 @@ pub struct Response {
 }
 
 impl Response {
-    /// Returns the response header with the given name (case-insensitive).
-    pub fn header(&self, name: &str) -> Option<&Header> {
-        self.headers
+    /// Returns all the response headers with the given name (case-insensitive). Returns `None` if
+    /// there are no matching headers. Returns `Some` if there is at least one matching header.
+    /// Never returns `Some` with an empty `Vec`.
+    pub fn header(&self, name: &str) -> Option<Vec<&Header>> {
+        let matching: Vec<&Header> = self
+            .headers
             .iter()
-            .find(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
+            .collect();
+        if matching.is_empty() {
+            None
+        } else {
+            Some(matching)
+        }
     }
 
     /// Shifts the span range by the given offset.


### PR DESCRIPTION
Adds `all_headers_with_name(&self, name: &str) -> Vec<&Header>` methods to `http::types::{Response, Request}` to support multiple headers with the same name. 

Previous `header` methods remain unchanged and return only the 1st header with a given name. `http`'s `HeaderMap` roughly [does the same](https://docs.rs/http/0.2.9/http/header/struct.HeaderMap.html#method.get_all).

Related to https://github.com/tlsnotary/tlsn/issues/374