### PR TITLE
fix: fix offset, forbid trailing chars in json, require utf8 in Span<…

### DIFF
--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -310,18 +310,18 @@ mod tests {
                         </html>";
 
     const TEST_REQUEST2: &[u8] = b"\
-                        GET /info.html HTTP/1.1\n\
-                        Host: tlsnotary.org\n\
-                        User-Agent: client\n\
-                        Content-Length: 4\n\
+                        GET /info.html HTTP/1.1\r\n\
+                        Host: tlsnotary.org\r\n\
+                        User-Agent: client\r\n\
+                        Content-Length: 4\r\n\r\n\
                         ping";
 
     const TEST_RESPONSE2: &[u8] = b"\
-                        HTTP/1.1 200 OK\n\
-                        Server: server\n\
-                        Content-Length: 4\n\
-                        Content-Type: text/plain\n\
-                        Connection: keep-alive\n\n\
+                        HTTP/1.1 200 OK\r\n\
+                        Server: server\r\n\
+                        Content-Length: 4\r\n\
+                        Content-Type: text/plain\r\n\
+                        Connection: keep-alive\r\n\r\n\
                         pong";
 
     #[test]

--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -401,11 +401,11 @@ mod tests {
     // Make sure the first response is not parsed.
     #[test]
     fn test_parse_response_from_bytes() {
-        let mut request = Vec::new();
-        request.extend(TEST_RESPONSE2);
-        request.extend(TEST_RESPONSE);
-        let request = Bytes::copy_from_slice(&request);
-        let res = parse_response_from_bytes(&request, TEST_RESPONSE2.len()).unwrap();
+        let mut response = Vec::new();
+        response.extend(TEST_RESPONSE2);
+        response.extend(TEST_RESPONSE);
+        let response = Bytes::copy_from_slice(&response);
+        let res = parse_response_from_bytes(&response, TEST_RESPONSE2.len()).unwrap();
 
         assert_eq!(res.span(), TEST_RESPONSE);
         assert_eq!(res.code, "200");

--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -381,7 +381,7 @@ mod tests {
         let req = parse_request_from_bytes(&request, TEST_REQUEST2.len()).unwrap();
 
         assert_eq!(req.span(), TEST_REQUEST);
-        assert_eq!(req.method, "GET");
+        assert_eq!(req.request.method, "GET");
         assert_eq!(
             req.headers_with_name("Host").next().unwrap().value.span(),
             b"developer.mozilla.org".as_slice()
@@ -408,8 +408,8 @@ mod tests {
         let res = parse_response_from_bytes(&response, TEST_RESPONSE2.len()).unwrap();
 
         assert_eq!(res.span(), TEST_RESPONSE);
-        assert_eq!(res.code, "200");
-        assert_eq!(res.reason, "OK");
+        assert_eq!(res.status.code, "200");
+        assert_eq!(res.status.reason, "OK");
         assert_eq!(
             res.headers_with_name("Server").next().unwrap().value.span(),
             b"Apache/2.2.14 (Win32)".as_slice()

--- a/src/json/span.rs
+++ b/src/json/span.rs
@@ -22,6 +22,14 @@ pub fn parse_str(src: &str) -> Result<JsonValue, ParseError> {
         .next()
         .ok_or_else(|| ParseError("no json value is present in source".to_string()))?;
 
+    // Since json.pest grammar prohibits leading characters but allows trailing
+    // characters, we prohibit trailing characters here.
+    if value.as_str().len() != src.len() {
+        return Err(ParseError(
+            "trailing characters are present in source".to_string(),
+        ));
+    }
+
     Ok(JsonValue::from_pair(src.clone(), value))
 }
 
@@ -38,6 +46,14 @@ pub fn parse(src: Bytes) -> Result<JsonValue, ParseError> {
     let value = JsonParser::parse(Rule::value, src_str)?
         .next()
         .ok_or_else(|| ParseError("no json value is present in source".to_string()))?;
+
+    // Since json.pest grammar prohibits leading characters but allows trailing
+    // characters, we prohibit trailing characters here.
+    if value.as_str().len() != src.len() {
+        return Err(ParseError(
+            "trailing characters are present in source".to_string(),
+        ));
+    }
 
     Ok(JsonValue::from_pair(src.clone(), value))
 }
@@ -136,5 +152,20 @@ mod tests {
         assert_eq!(value.get("baz").unwrap().span(), "123");
         assert_eq!(value.get("quux.a").unwrap().span(), "b");
         assert_eq!(value.get("arr").unwrap().span(), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn test_err_leading_characters() {
+        let src = " {\"foo\": \"bar\"}";
+        assert!(parse_str(src).is_err());
+    }
+
+    #[test]
+    fn test_err_trailing_characters() {
+        let src = "{\"foo\": \"bar\"} ";
+        assert_eq!(
+            parse_str(src).err().unwrap().to_string(),
+            "parsing error: trailing characters are present in source"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,11 @@ impl Span<str> {
     pub(crate) fn new_from_str(src: Bytes, span: &str) -> Self {
         let range = helpers::get_span_range(src.as_ref(), span.as_bytes());
 
-        Span::new_str(src, range)
+        Self {
+            data: src.slice(range.clone()),
+            range,
+            _pd: PhantomData,
+        }
     }
 
     /// Converts this type to a string slice.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,11 +144,7 @@ impl Span<str> {
     pub(crate) fn new_from_str(src: Bytes, span: &str) -> Self {
         let range = helpers::get_span_range(src.as_ref(), span.as_bytes());
 
-        Self {
-            data: src.slice(range.clone()),
-            range,
-            _pd: PhantomData,
-        }
+        Span::new_str(src, range)
     }
 
     /// Converts this type to a string slice.


### PR DESCRIPTION
This PR:
- fixes an offset in http parser and adds tests for that
- prohibits trailing characters when parsing a json value
- checks that Span<str> is built from a utf8 string 