### PR TITLE
refactor: http types

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,7 +6,7 @@ mod types;
 use bytes::Bytes;
 
 pub use span::{parse_request, parse_response};
-pub use types::{Body, Header, HeaderName, HeaderValue, Request, Response};
+pub use types::{Body, Header, HeaderName, HeaderValue, Request, RequestLine, Response, Status};
 
 use crate::ParseError;
 
@@ -109,7 +109,7 @@ mod tests {
 
         assert_eq!(reqs.len(), 2);
 
-        assert_eq!(reqs[0].method, "GET");
+        assert_eq!(reqs[0].request.method, "GET");
         assert!(reqs[0].body.is_none());
         assert_eq!(
             reqs[0]
@@ -121,7 +121,7 @@ mod tests {
             b"localhost"
         );
 
-        assert_eq!(reqs[1].method, "POST");
+        assert_eq!(reqs[1].request.method, "POST");
         assert_eq!(
             reqs[1]
                 .headers_with_name("host")
@@ -154,7 +154,7 @@ mod tests {
 
         assert_eq!(resps.len(), 3);
 
-        assert_eq!(resps[0].code, "200");
+        assert_eq!(resps[0].status.code, "200");
         assert_eq!(
             resps[0]
                 .headers_with_name("content-length")
@@ -166,7 +166,7 @@ mod tests {
         );
         assert!(resps[0].body.is_none());
 
-        assert_eq!(resps[1].code, "200");
+        assert_eq!(resps[1].status.code, "200");
         assert_eq!(
             resps[1]
                 .headers_with_name("content-length")
@@ -181,7 +181,7 @@ mod tests {
             b"Hello, world!\n".as_slice()
         );
 
-        assert_eq!(resps[2].code, "204");
+        assert_eq!(resps[2].status.code, "204");
         assert_eq!(
             resps[2]
                 .headers_with_name("content-length")

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -72,15 +72,40 @@ impl Spanned for Header {
     }
 }
 
+/// An HTTP request line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RequestLine {
+    pub(crate) span: Span<str>,
+
+    /// The request method.
+    pub method: Span<str>,
+    /// The request path.
+    pub path: Span<str>,
+}
+
+impl RequestLine {
+    /// Shifts the span range by the given offset.
+    pub fn offset(&mut self, offset: usize) {
+        self.span.offset(offset);
+        self.method.offset(offset);
+        self.path.offset(offset);
+    }
+}
+
+impl Spanned<str> for RequestLine {
+    fn span(&self) -> &Span<str> {
+        &self.span
+    }
+}
+
 /// An HTTP request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Request {
     pub(crate) span: Span,
-    /// The request method.
-    pub method: Span<str>,
-    /// The request path.
-    pub path: Span<str>,
+    /// The request line.
+    pub request: RequestLine,
     /// Request headers.
     pub headers: Vec<Header>,
     /// Request body.
@@ -92,7 +117,7 @@ impl Request {
     ///
     /// This method returns an iterator because it is valid for HTTP records to contain
     /// duplicate header names.
-    pub fn headers_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Header> + 'a {
+    pub fn headers_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Header> {
         self.headers
             .iter()
             .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
@@ -101,8 +126,7 @@ impl Request {
     /// Shifts the span range by the given offset.
     pub fn offset(&mut self, offset: usize) {
         self.span.offset(offset);
-        self.method.offset(offset);
-        self.path.offset(offset);
+        self.request.offset(offset);
         for header in &mut self.headers {
             header.offset(offset);
         }
@@ -118,15 +142,40 @@ impl Spanned for Request {
     }
 }
 
+/// An HTTP response status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Status {
+    pub(crate) span: Span<str>,
+
+    /// The response code.
+    pub code: Span<str>,
+    /// The reason phrase.
+    pub reason: Span<str>,
+}
+
+impl Status {
+    /// Shifts the span range by the given offset.
+    pub fn offset(&mut self, offset: usize) {
+        self.span.offset(offset);
+        self.code.offset(offset);
+        self.reason.offset(offset);
+    }
+}
+
+impl Spanned<str> for Status {
+    fn span(&self) -> &Span<str> {
+        &self.span
+    }
+}
+
 /// An HTTP response.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Response {
     pub(crate) span: Span,
-    /// The response code.
-    pub code: Span<str>,
-    /// The reason phrase.
-    pub reason: Span<str>,
+    /// The response status.
+    pub status: Status,
     /// Response headers.
     pub headers: Vec<Header>,
     /// Response body.
@@ -138,7 +187,7 @@ impl Response {
     ///
     /// This method returns an iterator because it is valid for HTTP records to contain
     /// duplicate header names.
-    pub fn headers_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Header> + 'a {
+    pub fn headers_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Header> {
         self.headers
             .iter()
             .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
@@ -147,8 +196,7 @@ impl Response {
     /// Shifts the span range by the given offset.
     pub fn offset(&mut self, offset: usize) {
         self.span.offset(offset);
-        self.code.offset(offset);
-        self.reason.offset(offset);
+        self.status.offset(offset);
         for header in &mut self.headers {
             header.offset(offset);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,11 @@ impl<T: ?Sized> Span<T> {
         self.data.as_ref()
     }
 
+    /// Converts the span into bytes.
+    pub fn to_bytes(self) -> Bytes {
+        self.data
+    }
+
     /// Returns the corresponding range within the source string.
     pub fn range(&self) -> Range<usize> {
         self.range.clone()


### PR DESCRIPTION
This PR refactors the HTTP types a bit.

# Changes
- Added `RequestLine` and `Status` types which encapsulates these objects which are well defined in [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#page-21)
- Added method for getting the inner `Bytes` of a span
- Removes unnecessary lifetime captures in `headers_with_name` methods.