### PR TITLE
feat: subspans

### DIFF
--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -64,7 +64,7 @@ pub(crate) fn parse_request_from_bytes(src: &Bytes, offset: usize) -> Result<Req
         request: RequestLine {
             span: Span::new_str(src.clone(), request_line_range),
             method: Span::new_str(src.clone(), get_span_range(src, method)),
-            path: Span::new_from_str(src.clone(), path),
+            target: Span::new_from_str(src.clone(), path),
         },
         headers,
         body: None,

--- a/src/http/span.rs
+++ b/src/http/span.rs
@@ -86,7 +86,9 @@ pub(crate) fn parse_request_from_bytes(src: &Bytes, offset: usize) -> Result<Req
 
         request.span = Span::new_bytes(src.clone(), offset..range.end);
 
-        request.body = Some(Body(Span::new_bytes(src.clone(), range)));
+        request.body = Some(Body {
+            span: Span::new_bytes(src.clone(), range),
+        });
     }
 
     Ok(request)
@@ -172,7 +174,9 @@ pub(crate) fn parse_response_from_bytes(
 
         response.span = Span::new_bytes(src.clone(), offset..range.end);
 
-        response.body = Some(Body(Span::new_bytes(src.clone(), range)));
+        response.body = Some(Body {
+            span: Span::new_bytes(src.clone(), range),
+        });
     }
 
     Ok(response)

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -219,6 +219,18 @@ impl Response {
             .filter(|h| h.name.0.as_str().eq_ignore_ascii_case(name))
     }
 
+    /// Returns the indices of the response excluding the headers and body.
+    pub fn without_data(&self) -> RangeSet<usize> {
+        let mut indices = self.span.indices.clone();
+        for header in &self.headers {
+            indices = indices.difference(header.span.indices());
+        }
+        if let Some(body) = &self.body {
+            indices = indices.difference(body.span.indices());
+        }
+        indices
+    }
+
     /// Shifts the span range by the given offset.
     pub fn offset(&mut self, offset: usize) {
         self.span.offset(offset);

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -48,7 +48,7 @@ impl Spanned for HeaderValue {
     }
 }
 
-/// An HTTP header, including the trailing CRLF.
+/// An HTTP header, including optional whitespace and the trailing CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Header {
@@ -61,6 +61,8 @@ pub struct Header {
 
 impl Header {
     /// Returns the indices of the header excluding the value.
+    ///
+    /// The indices will include any optional whitespace and the CRLF.
     pub fn without_value(&self) -> RangeSet<usize> {
         self.span.indices.difference(&self.value.span().indices)
     }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -89,21 +89,21 @@ pub struct RequestLine {
 
     /// The request method.
     pub method: Span<str>,
-    /// The request path.
-    pub path: Span<str>,
+    /// The request target.
+    pub target: Span<str>,
 }
 
 impl RequestLine {
-    /// Returns the indices of the request line excluding the path.
-    pub fn without_path(&self) -> RangeSet<usize> {
-        self.span.indices.difference(&self.path.indices)
+    /// Returns the indices of the request line excluding the request target.
+    pub fn without_target(&self) -> RangeSet<usize> {
+        self.span.indices.difference(&self.target.indices)
     }
 
     /// Shifts the span range by the given offset.
     pub fn offset(&mut self, offset: usize) {
         self.span.offset(offset);
         self.method.offset(offset);
-        self.path.offset(offset);
+        self.target.offset(offset);
     }
 }
 
@@ -139,7 +139,7 @@ impl Request {
 
     /// Returns the indices of the request excluding the path, headers and body.
     pub fn without_data(&self) -> RangeSet<usize> {
-        let mut indices = self.span.indices.difference(&self.request.path.indices);
+        let mut indices = self.span.indices.difference(&self.request.target.indices);
         for header in &self.headers {
             indices = indices.difference(header.span.indices());
         }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -137,7 +137,7 @@ impl Request {
 
     /// Returns the indices of the request excluding the path, headers and body.
     pub fn without_data(&self) -> RangeSet<usize> {
-        let mut indices = self.span.indices.difference(&self.request.span.indices);
+        let mut indices = self.span.indices.difference(&self.request.path.indices);
         for header in &self.headers {
             indices = indices.difference(header.span.indices());
         }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -48,7 +48,7 @@ impl Spanned for HeaderValue {
     }
 }
 
-/// An HTTP header.
+/// An HTTP header, including the trailing CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Header {
@@ -79,7 +79,7 @@ impl Spanned for Header {
     }
 }
 
-/// An HTTP request line.
+/// An HTTP request line, including the trailing CRLF.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RequestLine {

--- a/src/json/types.rs
+++ b/src/json/types.rs
@@ -200,7 +200,7 @@ impl Index<usize> for Array {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// An object value.
+/// A JSON object value.
 pub struct Object {
     pub(crate) span: Span<str>,
     /// The key value pairs of the object.

--- a/src/json/types.rs
+++ b/src/json/types.rs
@@ -168,7 +168,7 @@ impl Array {
         }
     }
 
-    /// Returns the indices of the array, excluding the values.
+    /// Returns the indices of the array, excluding the values and separators.
     pub fn without_values(&self) -> RangeSet<usize> {
         let start = self
             .span

--- a/src/json/types.rs
+++ b/src/json/types.rs
@@ -1,4 +1,6 @@
-use std::ops::Range;
+use std::ops::{Index, Range};
+
+use utils::range::{RangeDifference, RangeSet};
 
 use crate::{Span, Spanned};
 
@@ -108,6 +110,13 @@ pub struct KeyValue {
     pub value: JsonValue,
 }
 
+impl KeyValue {
+    /// Returns the indices of the key value pair, excluding the value.
+    pub fn without_value(&self) -> RangeSet<usize> {
+        self.span.indices.difference(&self.value.span().indices)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A key in a JSON object.
@@ -142,15 +151,6 @@ pub struct Array {
     pub elems: Vec<JsonValue>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// An object value.
-pub struct Object {
-    pub(crate) span: Span<str>,
-    /// The key value pairs of the object.
-    pub elems: Vec<KeyValue>,
-}
-
 impl Array {
     /// Get a reference to the value using the given path.
     pub fn get(&self, path: &str) -> Option<&JsonValue> {
@@ -167,11 +167,49 @@ impl Array {
             Some(value)
         }
     }
+
+    /// Returns the indices of the array, excluding the values.
+    pub fn without_values(&self) -> RangeSet<usize> {
+        let start = self
+            .span
+            .indices
+            .min()
+            .expect("array has at least brackets");
+        let end = self
+            .span
+            .indices
+            .max()
+            .expect("array has at least brackets");
+
+        RangeSet::from([start..start + 1, end..end + 1])
+    }
+}
+
+impl Index<usize> for Array {
+    type Output = JsonValue;
+
+    /// Returns the value at the given index of the array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    fn index(&self, index: usize) -> &Self::Output {
+        self.elems.get(index).expect("index is in bounds")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// An object value.
+pub struct Object {
+    pub(crate) span: Span<str>,
+    /// The key value pairs of the object.
+    pub elems: Vec<KeyValue>,
 }
 
 impl Object {
     /// Get a reference to the value using the given path.
-    fn get(&self, path: &str) -> Option<&JsonValue> {
+    pub fn get(&self, path: &str) -> Option<&JsonValue> {
         let mut path_iter = path.split('.');
 
         let key = path_iter.next()?;
@@ -183,6 +221,28 @@ impl Object {
         } else {
             Some(value)
         }
+    }
+
+    /// Returns the indices of the object, excluding the key value pairs.
+    pub fn without_pairs(&self) -> RangeSet<usize> {
+        let mut indices = self.span.indices.clone();
+        for kv in &self.elems {
+            indices = indices.difference(&kv.span.indices);
+        }
+        indices
+    }
+}
+
+impl Index<&str> for Object {
+    type Output = JsonValue;
+
+    /// Returns the value at the given key of the object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key is not present.
+    fn index(&self, key: &str) -> &Self::Output {
+        self.get(key).expect("key is present")
     }
 }
 
@@ -267,6 +327,8 @@ impl_type!(KeyValue, span);
 
 #[cfg(test)]
 mod tests {
+    use utils::range::IndexRanges;
+
     use crate::json::parse_str;
 
     use super::*;
@@ -296,5 +358,44 @@ mod tests {
         let value = parse_str(src).unwrap();
 
         assert_eq!(value.get("foo.bar.1").unwrap().span(), "14");
+    }
+
+    #[test]
+    fn test_key_value_without_value() {
+        let src = "{\"foo\": \"bar\"\n}";
+
+        let JsonValue::Object(value) = parse_str(src).unwrap() else {
+            panic!("expected object");
+        };
+
+        let indices = value.elems[0].without_value();
+
+        assert_eq!(src.index_ranges(&indices), "\"foo\": \"\"");
+    }
+
+    #[test]
+    fn test_array_without_values() {
+        let src = "[42, 14]";
+
+        let JsonValue::Array(value) = parse_str(src).unwrap() else {
+            panic!("expected object");
+        };
+
+        let indices = value.without_values();
+
+        assert_eq!(src.index_ranges(&indices), "[]");
+    }
+
+    #[test]
+    fn test_object_without_pairs() {
+        let src = "{\"foo\": \"bar\"\n}";
+
+        let JsonValue::Object(value) = parse_str(src).unwrap() else {
+            panic!("expected object");
+        };
+
+        let indices = value.without_pairs();
+
+        assert_eq!(src.index_ranges(&indices), "{\n}");
     }
 }


### PR DESCRIPTION
This PR builds on #11 and adds the "subspan" methods we use in `tlsn-formats`.